### PR TITLE
chore: add types

### DIFF
--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,0 +1,17 @@
+export type Item = {
+	id: number;
+	title: string;
+	points: number | null;
+	user: string | null;
+	time: number;
+	time_ago: string;
+	content: string;
+	deleted?: boolean;
+	dead?: boolean;
+	type: string;
+	url?: string;
+	domain?: string;
+	comments: Item[]; // Comments are items too
+	level: number;
+	comments_count: number;
+};

--- a/src/routes/[list=category]/[page]/item-summary.svelte
+++ b/src/routes/[list=category]/[page]/item-summary.svelte
@@ -2,7 +2,7 @@
 	import Capsule from '$lib/capsule.svelte';
 	import { ChatBubbleIcon } from '$lib/icons';
 
-	/** @type {{ id: number, domain: string, url: string, user: string, title: string, time_ago: string, points: number, comments_count: number }} */
+	/** @type {import('$lib/types').Item} */
 	export let item;
 	export let index;
 

--- a/src/routes/item/[id]/comment.svelte
+++ b/src/routes/item/[id]/comment.svelte
@@ -2,15 +2,20 @@
 	import { LinkIcon } from '$lib/icons';
 	import { page } from '$app/stores';
 
-	export let author;
+	/** @type {import('$lib/types').Item} */
 	export let comment;
+
+	/** @type string */
+	export let author;
+
+	/** @type string */
 	export let rootId;
 
 	$: isTarget = $page.url.hash === `#${comment.id}`;
 </script>
 
 {#if !comment.deleted}
-	<article id={comment.id} class:isTarget>
+	<article id={comment.id.toString()} class:isTarget>
 		<details open class="mt-6">
 			<summary class="flex items-center gap-1.5 text-subtle">
 				<div class="flex w-full items-center gap-1.5 text-sm font-medium">

--- a/src/routes/item/[id]/comment.svelte
+++ b/src/routes/item/[id]/comment.svelte
@@ -58,7 +58,7 @@
 	</article>
 {/if}
 
-<style>
+<style lang="postcss">
 	.isTarget > details > summary,
 	.isTarget > details > .formatted-content {
 		@apply bg-primary/5;


### PR DESCRIPTION
Adds type for items (posts and comments) per [HNPWA API docs](https://github.com/tastejs/hacker-news-pwas/blob/master/docs/api.md).

Also adds postCSS specifier in comment component to fix type errors.