### PR TITLE
fix: blockquotes not always properly detected

### DIFF
--- a/src/lib/content.svelte
+++ b/src/lib/content.svelte
@@ -1,10 +1,12 @@
 <script>
 	export let content = '';
 
+	/** @param {string} content */
 	function formatContent(content) {
-		return content.replaceAll(
-			/<p>&gt; (.*?)</gm,
-			"<p class='blockquote'>&gt; $1<"
+		return (
+			content
+				// Style blockquotes
+				.replaceAll(/<p>(<i>)?(&gt;.*?)(<p>)?/gm, "<p class='blockquote'>$1$2")
 		);
 	}
 </script>


### PR DESCRIPTION
This fixes blockquote detection when multiple quotes exist in a single post/comment or if the quote contains italics.