### PR TITLE
feat: category list items navigate directly to the item page

### DIFF
--- a/src/routes/[list=category]/[page]/item-summary.svelte
+++ b/src/routes/[list=category]/[page]/item-summary.svelte
@@ -1,45 +1,28 @@
 <script>
-	import Capsule from '$lib/capsule.svelte';
-	import { ChatBubbleIcon } from '$lib/icons';
-
 	/** @type {import('$lib/types').Item} */
 	export let item;
 	export let index;
-
-	$: postLink = `/item/${item.id}`;
 </script>
 
-<article
-	id={item.id.toString()}
-	class="py-6 first:pt-0 [&:not(:last-of-type)]:border-b"
->
-	<h2 class="max-w-lg">
-		<a
-			href={item.domain ? item.url : postLink}
-			class="text-lg font-bold visited:text-subtle">{item.title}</a
-		>
-	</h2>
+<div class="border-b">
+	<a id={item.id.toString()} href="/item/{item.id}">
+		<article class="my-3 w-full space-y-1.5 rounded-lg p-3 hover:bg-surface/50">
+			<h1 class="max-w-lg text-lg font-semibold visited:text-subtle">
+				{item.title}
+			</h1>
 
-	<p class="mt-1.5 flex cursor-default select-none items-center gap-1.5">
-		<time class="flex items-center text-xs font-medium text-subtle">
-			{item.time_ago.replace(/(a|an)\W.*?/, '1 ')}
-		</time>
-
-		{#if item.domain}
-			<span
-				class="inline-flex items-center font-mono text-xs font-medium text-subtle"
-				>({item.domain})
-			</span>
-		{/if}
-	</p>
-
-	<div class="mt-6 flex flex-wrap items-center gap-1.5">
-		<Capsule href={postLink}>
-			<ChatBubbleIcon size={16} />
-			<p>
+			<p class="flex items-center font-mono text-xs font-medium text-subtle">
 				{item.comments_count}
-				{item.comments_count === 1 ? 'comment' : 'comments'}
+				{item.comments_count === 1 ? 'comment' : 'comments'}, {item.time_ago.replace(
+					/(a|an)\W.*?/,
+					'1 ',
+				)}
+				{#if item.domain}
+					&mdash;&nbsp;<a href={item.url} class="truncate hover:underline"
+						>{item.domain}</a
+					>
+				{/if}
 			</p>
-		</Capsule>
-	</div>
-</article>
+		</article>
+	</a>
+</div>


### PR DESCRIPTION
This removes individual links to the article and comments in favour of always navigating to the item page.